### PR TITLE
feat: Add auto fill of login form if credentials are present

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,24 @@ class TemplateContentScript extends ContentScript {
 
   async waitForUserAuthentication() {
     this.log('info', 'waitForUserAuthentication starts')
+
+    const credentials = await this.getCredentials()
+
+    if (credentials) {
+      this.log(
+        'debug',
+        'found credentials, filling fields and waiting for captcha resolution'
+      )
+      const loginFieldSelector = '#username'
+      const passwordFieldSelector = '#password'
+      await this.runInWorker('fillText', loginFieldSelector, credentials.login)
+      await this.runInWorker(
+        'fillText',
+        passwordFieldSelector,
+        credentials.password
+      )
+    }
+
     await this.setWorkerState({ visible: true })
     await this.runInWorkerUntilTrue({ method: 'waitForAuthenticated' })
     await this.setWorkerState({ visible: false })


### PR DESCRIPTION
J'isole déjà cette feature d'autofill des champs login. Je propose de la merger. Car le reste (interférence RED) est très prise de tête.

C'est testé sur une stack locale.
Le login et mot de passe sont renseignés automatiquement si disponible.
Ensuite le connecteur est mis en attente pour que l'utilisateur valide le captcha.

