### PR TITLE
fix: Fix bills scraping for all contracts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
 import { ContentScript } from 'cozy-clisk/dist/contentscript'
-import { blobToBase64 } from 'cozy-clisk/dist/contentscript/utils'
-import ky from 'ky'
 import Minilog from '@cozy/minilog'
 import waitFor, { TimeoutError } from 'p-wait-for'
 import pRetry from 'p-retry'
@@ -35,33 +33,28 @@ class SfrContentScript extends ContentScript {
     await this.waitForUserAuthentication()
   }
 
-  async waitForCurrentContract(contract) {
-    await waitFor(
-      async () => {
-        const el = document.querySelector(`li[id='${contract.id}']`)
-        if (el) {
-          el.click()
-          return false
-        } else {
-          const currentContract = await this.getCurrentContract()
-          if (!currentContract) {
-            return false
-          }
-          const result = currentContract.text === contract.text
-          return result
-        }
-      },
-      {
-        interval: 1000,
-        timeout: {
-          milliseconds: 10000,
-          message: new TimeoutError(
-            'waitForCurrentContract ' + contract.text + ' timed out after 10sec'
-          )
-        }
-      }
+  async navigateToNextContract(contract) {
+    this.log(
+      'info',
+      `📍️ navigateToNextContract starts for ${JSON.stringify(contract.text)}`
     )
-    return true
+    // Removing elements here is to ensure we're not finding the awaited elements
+    // before the next contract is loaded
+    if (await this.isElementInWorker('#plusFac')) {
+      await this.evaluateInWorker(function removeElement() {
+        document.querySelector('#lastFacture').remove()
+      })
+    } else {
+      await this.evaluateInWorker(function removeElement() {
+        document.querySelector('div[class="sr-inline sr-xs-block "]').remove()
+      })
+    }
+    await this.runInWorker('click', `li[id='${contract.id}']`)
+    await Promise.race([
+      this.waitForElementInWorker('div[class="sr-inline sr-xs-block"]'),
+      this.waitForElementInWorker('div[class="sr-inline sr-xs-block "]'),
+      this.waitForElementInWorker('#lastFacture')
+    ])
   }
 
   async ensureRedNotAuthenticated() {
@@ -176,32 +169,41 @@ class SfrContentScript extends ContentScript {
       `a[href='https://espace-client.sfr.fr/gestion-ligne/lignes/ajouter']`
     )
     const contracts = await this.runInWorker('getContracts')
+    let isFirstContract = true
+    await this.goto(CLIENT_SPACE_URL)
+    await this.waitForElementInWorker(
+      `a[href='https://espace-client.sfr.fr/gestion-ligne/lignes/ajouter']`
+    )
     for (const contract of contracts) {
       const contractName = contract.text
-      await this.goto(CLIENT_SPACE_URL)
-      await this.waitForElementInWorker(
-        `a[href='https://espace-client.sfr.fr/gestion-ligne/lignes/ajouter']`
-      )
-      // first contract is the current one
-      await this.goto('https://www.sfr.fr/routage/info-conso')
-      await this.waitForElementInWorker('.sr-tabs')
       if (contract.id !== 'current') {
-        await this.runInWorkerUntilTrue({
-          method: 'waitForCurrentContract',
-          args: [contract]
-        })
+        await this.navigateToNextContract(contract)
       }
-      await this.fetchCurrentContractBills(contractName, context)
+      await this.fetchCurrentContractBills(
+        contractName,
+        context,
+        isFirstContract
+      )
+      isFirstContract = false
     }
   }
 
-  async fetchCurrentContractBills(contractName, context) {
+  async fetchCurrentContractBills(contractName, context, isFirst) {
     this.log('info', '🤖 Fetching current contract: ' + contractName)
-    await this.goto(BASE_CLIENT_URL + BILLS_URL_PATH)
-    await this.waitForElementInWorker(
+    if (isFirst) {
+      await this.goto(BASE_CLIENT_URL + BILLS_URL_PATH)
+    }
+    await Promise.race([
+      this.waitForElementInWorker('#blocAjax'),
+      this.waitForElementInWorker('#historique')
+    ])
+    const altButton = await this.isElementInWorker('#plusFac')
+    const normalButton = await this.isElementInWorker(
       'button[onclick="plusFacture(); return false;"]'
     )
-    await this.runInWorker('getMoreBills')
+    if (altButton || normalButton) {
+      await this.runInWorker('getMoreBills')
+    }
     await this.runInWorker('getBills', contractName)
     await this.saveBills(this.store.allBills, {
       context,
@@ -249,6 +251,7 @@ class SfrContentScript extends ContentScript {
   }
 
   async waitForRedUrl() {
+    this.log('info', '📍️ waitForRedUrl starts')
     await waitFor(this.isRedUrl, {
       interval: 100,
       timeout: {
@@ -301,6 +304,7 @@ class SfrContentScript extends ContentScript {
   }
 
   async getUserMail() {
+    this.log('info', '📍️ getUserMail starts')
     const userMailElement = document.querySelector('#emailContact').innerHTML
     if (userMailElement) {
       return userMailElement
@@ -330,14 +334,14 @@ class SfrContentScript extends ContentScript {
     const addressWords = unspacedAddress.match(/([A-Z ]{1,})/g)
     const street = addressWords[0].replace(/^ +/g, '').replace(/ +$/g, '')
     const city = addressWords[1].replace(/^ +/g, '').replace(/ +$/g, '')
-    const mobilePhoneNumber = document.querySelector(
-      '#telephoneContactMobile'
-    ).innerHTML
+    const mobilePhoneNumber = document
+      .querySelector('#telephoneContactMobile')
+      .innerHTML.trim()
     let homePhoneNumber = null
     if (document.querySelector('#telephoneContactFixe')) {
-      homePhoneNumber = document.querySelector(
-        '#telephoneContactFixe'
-      ).innerHTML
+      homePhoneNumber = document
+        .querySelector('#telephoneContactFixe')
+        .innerHTML.trim()
     }
     const email = document.querySelector('#emailContact').innerHTML
     const userIdentity = {
@@ -373,6 +377,7 @@ class SfrContentScript extends ContentScript {
   }
 
   async getContracts() {
+    this.log('info', '📍️ getContracts starts')
     const contracts = Array.from(
       document
         .querySelector(
@@ -381,14 +386,25 @@ class SfrContentScript extends ContentScript {
         .parentNode.parentNode.querySelectorAll('li')
     )
       .filter(el => !el.getAttribute('class'))
-      .map(el => ({
-        id: el.getAttribute('id') || 'current',
-        text: el.innerHTML.trim()
-      }))
+      .map(el => {
+        const text = el.innerHTML.trim()
+        let type
+        if (text.startsWith('06') || text.startsWith('07')) {
+          type = 'mobile'
+        } else {
+          type = 'fixe'
+        }
+        return {
+          id: el.getAttribute('id') || 'current',
+          text,
+          type
+        }
+      })
     return contracts
   }
 
   async getCurrentContract() {
+    this.log('info', '📍️ getCurrentContract starts')
     try {
       const contracts = await this.getContracts()
       const currentContract = contracts.find(
@@ -405,23 +421,57 @@ class SfrContentScript extends ContentScript {
   }
 
   async getMoreBills() {
+    this.log('info', '📍️ getMoreBills starts')
     const moreBillsSelector = 'button[onclick="plusFacture(); return false;"]'
-    while (document.querySelector(`${moreBillsSelector}`) !== null) {
-      this.log('debug', 'moreBillsButton detected, clicking')
-      const moreBillsButton = document.querySelector(`${moreBillsSelector}`)
-      moreBillsButton.click()
-      // Here, we need to wait for the older bills to load on the page
-      await sleep(3)
+    const moreBillAltWrapperSelector = '#plusFacWrap'
+    const moreBillAltSelector = '#plusFac'
+    if (document.querySelector(moreBillsSelector)) {
+      while (document.querySelector(`${moreBillsSelector}`) !== null) {
+        this.log('debug', 'moreBillsButton detected, clicking')
+        const moreBillsButton = document.querySelector(`${moreBillsSelector}`)
+        moreBillsButton.click()
+        // Here, we need to wait for the older bills to load on the page
+        await sleep(3)
+      }
+    }
+    if (
+      document.querySelector(moreBillAltSelector) &&
+      document.querySelector(moreBillAltWrapperSelector)
+    ) {
+      while (
+        !document
+          .querySelector(`${moreBillAltWrapperSelector}`)
+          .getAttribute('style')
+      ) {
+        this.log('debug', 'moreBillsButton detected, clicking')
+        const moreBillsButton = document.querySelector(`${moreBillAltSelector}`)
+        moreBillsButton.click()
+        // Here, we need to wait for the older bills to load on the page
+        await sleep(3)
+      }
     }
     this.log('debug', 'No more moreBills button')
   }
 
   async getBills(contractName) {
-    const lastBill = await this.findLastBill(contractName)
-    this.log('debug', 'Last bill returned, getting old ones')
-    const oldBills = await this.findOldBills(contractName)
-    const allBills = lastBill.concat(oldBills)
-    this.log('debug', 'Old bills returned, sending to Pilot')
+    this.log('info', '📍️ getBills starts')
+    let lastBill
+    let allBills
+    // Selector of the alternative lastBill element
+    if (document.querySelector('#lastFacture')) {
+      lastBill = await this.findAltLastBill(contractName)
+      this.log('debug', 'Last bill returned, getting old ones')
+      const oldBills = await this.findAltOldBills(contractName)
+      allBills = lastBill.concat(oldBills)
+      this.log('debug', 'Old bills returned, sending to Pilot')
+    } else {
+      lastBill = await this.findLastBill(contractName)
+      this.log('debug', 'Last bill returned, getting old ones')
+      const oldBills = await this.findOldBills(contractName)
+      allBills = lastBill.concat(oldBills)
+      this.log('debug', 'Old bills returned, sending to Pilot')
+    }
+
     await this.sendToPilot({
       allBills
     })
@@ -429,11 +479,22 @@ class SfrContentScript extends ContentScript {
   }
 
   async findLastBill(contractName) {
-    this.log('debug', 'findLastBill starts')
+    this.log('info', '📍️ findLastBill starts')
     let lastBill = []
     const lastBillElement = document.querySelector(
       'div[class="sr-inline sr-xs-block "]'
     )
+    this.log(
+      'info',
+      `lastBillElement : ${JSON.stringify(Boolean(lastBillElement))}`
+    )
+    if (lastBillElement.innerHTML.includes('à partir du')) {
+      this.log(
+        'info',
+        'This bill has no dates to fetch yet, fetching it when dates has been given'
+      )
+      return []
+    }
     const rawAmount = lastBillElement
       .querySelectorAll('div')[0]
       .querySelector('span').innerHTML
@@ -441,6 +502,7 @@ class SfrContentScript extends ContentScript {
       .replace(/&nbsp;/g, '')
       .replace(/ /g, '')
       .replace(/\n/g, '')
+
     const amount = parseFloat(fullAmount.replace('€', ''))
     const currency = fullAmount.replace(/[0-9]*/g, '')
     const rawDate = lastBillElement
@@ -450,7 +512,6 @@ class SfrContentScript extends ContentScript {
     const day = dateArray[0]
     const month = dateArray[1]
     const year = dateArray[2]
-    const date = `${day}-${month}-${year}`
     const rawPaymentDate = lastBillElement
       .querySelectorAll('div')[1]
       .querySelectorAll('span')[0].innerHTML
@@ -459,8 +520,7 @@ class SfrContentScript extends ContentScript {
     const paymentMonth = paymentArray[1]
     const paymentYear = paymentArray[2]
     const filepath = lastBillElement
-      .querySelectorAll('div')[3]
-      .querySelector('a')
+      .querySelector('#lien-telecharger-pdf')
       .getAttribute('href')
     const fileurl = `${BASE_CLIENT_URL}${filepath}`
     const computedLastBill = {
@@ -468,7 +528,8 @@ class SfrContentScript extends ContentScript {
       currency: currency === '€' ? 'EUR' : currency,
       date: new Date(`${month}/${day}/${year}`),
       paymentDate: new Date(`${paymentMonth}/${paymentDay}/${paymentYear}`),
-      filename: await getFileName(rawDate, amount, currency),
+      filename: await getFileName(`${year}/${month}/${day}`, amount, currency),
+      fileurl,
       vendor: 'sfr',
       subPath: contractName,
       fileAttributes: {
@@ -482,38 +543,92 @@ class SfrContentScript extends ContentScript {
         }
       }
     }
-    if (lastBillElement.children[2].querySelectorAll('a')[1] !== undefined) {
-      const detailedFilepath = lastBillElement.children[2]
-        .querySelectorAll('a')[1]
+    if (
+      lastBillElement.querySelectorAll('[id*="lien-telecharger-"]').length > 1
+    ) {
+      const detailedFilepath = lastBillElement
+        .querySelector('[id*="lien-telecharger-fadet"]')
         .getAttribute('href')
       const detailed = detailedFilepath.match('detail') ? true : false
       const detailedBill = {
         ...computedLastBill
       }
       detailedBill.filename = await getFileName(
-        date,
+        `${year}/${month}/${day}`,
         amount,
         currency,
         detailed
       )
-      const fileurl = `${BASE_CLIENT_URL}${detailedFilepath}`
-      const response = await ky.get(fileurl).blob()
-      const dataUri = await blobToBase64(response)
-      detailedBill.dataUri = dataUri
+      detailedBill.fileurl = `${BASE_CLIENT_URL}${detailedFilepath}`
       lastBill.push(detailedBill)
     }
-    // As it's impossible to have the pilot on the same domain as the worker
-    // to match domain's specific cookie for the download to be done by saveFiles
-    // we need to fetch the stream then pass it to the pilot
-    const response = await ky.get(fileurl).blob()
-    const dataUri = await blobToBase64(response)
-    computedLastBill.dataUri = dataUri
+    lastBill.push(computedLastBill)
+    return lastBill
+  }
+
+  async findAltLastBill(contractName) {
+    this.log('info', '📍️ findAltLastBill starts')
+    let lastBill = []
+    const lastBillElement = document.querySelector(
+      'div[class="sr-inline sr-xs-block"]'
+    )
+    const rawAmount = lastBillElement
+      .querySelectorAll('div')[0]
+      .querySelector('span').innerHTML
+    const fullAmount = rawAmount
+      .replace(/&nbsp;/g, '')
+      .replace(/ /g, '')
+      .replace(/\n/g, '')
+    const amount = parseFloat(fullAmount.replace('€', '').replace(',', '.'))
+    const currency = fullAmount.replace(/[0-9]*/g, '').replace(',', '')
+    const rawDate = lastBillElement
+      .querySelectorAll('div')[1]
+      .querySelectorAll('div')[1].innerHTML
+
+    const dateArray = rawDate.split('/')
+    const day = dateArray[0].split('du')[1].trim()
+    const month = dateArray[1].trim()
+    const year = dateArray[2].trim()
+    const filepath = lastBillElement.querySelector('a').getAttribute('href')
+    const fileurl = `${BASE_CLIENT_URL}${filepath}`
+    const computedLastBill = {
+      amount,
+      currency: currency === '€' ? 'EUR' : currency,
+      date: new Date(`${month}/${day}/${year}`),
+      filename: await getFileName(`${year}-${month}-${day}`, amount, currency),
+      fileurl,
+      vendor: 'sfr',
+      subPath: contractName,
+      fileAttributes: {
+        metadata: {
+          contentAuthor: 'sfr',
+          datetime: new Date(`${month}/${day}/${year}`),
+          datetimeLabel: 'issueDate',
+          isSubscription: true,
+          issueDate: new Date(`${month}/${day}/${year}`),
+          carbonCopy: true
+        }
+      }
+    }
+    if (amount !== 0) {
+      const rawPaymentDate = lastBillElement
+        .querySelectorAll('div')[1]
+        .querySelectorAll('div')[0].innerHTML
+      const paymentArray = rawPaymentDate.split('/')
+      const paymentDay = paymentArray[0]
+      const paymentMonth = paymentArray[1]
+      const paymentYear = paymentArray[2]
+      const paymentDate = new Date(
+        `${paymentMonth}/${paymentDay}/${paymentYear}`
+      )
+      computedLastBill.paymentDate = paymentDate
+    }
     lastBill.push(computedLastBill)
     return lastBill
   }
 
   async findOldBills(contractName) {
-    this.log('debug', 'findOldBills starts')
+    this.log('info', '📍️ findOldBill starts')
     let oldBills = []
     const allBillsElements = document
       .querySelector('#blocAjax')
@@ -522,7 +637,7 @@ class SfrContentScript extends ContentScript {
     for (const oneBill of allBillsElements) {
       this.log(
         'debug',
-        `fetching bill ${counter++}/${allBillsElements.length}...`
+        `fetching bill ${counter + 1}/${allBillsElements.length}...`
       )
       const rawAmount = oneBill.children[0].querySelector('span').innerHTML
       const fullAmount = rawAmount
@@ -536,13 +651,12 @@ class SfrContentScript extends ContentScript {
       const day = dateArray[0]
       const month = computeMonth(dateArray[1])
       const year = dateArray[2]
-      const date = `${day}-${month}-${year}`
       const rawPaymentDate = oneBill.children[1].innerHTML
         .replace(/\n/g, '')
         .replace(/ /g, '')
         .match(/([0-9]{2}[a-zûé]{3,4}.?-)/g)
-      const filepath = oneBill.children[4]
-        .querySelector('a')
+      const filepath = oneBill
+        .querySelector('[id*="lien-duplicata-pdf-"]')
         .getAttribute('href')
       const fileurl = `${BASE_CLIENT_URL}${filepath}`
 
@@ -550,7 +664,12 @@ class SfrContentScript extends ContentScript {
         amount,
         currency: currency === '€' ? 'EUR' : currency,
         date: new Date(`${month}/${day}/${year}`),
-        filename: await getFileName(date, amount, currency),
+        filename: await getFileName(
+          `${year}/${month}/${day}`,
+          amount,
+          currency
+        ),
+        fileurl,
         vendor: 'sfr',
         subPath: contractName,
         fileAttributes: {
@@ -578,36 +697,150 @@ class SfrContentScript extends ContentScript {
           `${paymentMonth}/${paymentDay}/${paymentYear}`
         )
       }
-      if (oneBill.children[4].querySelectorAll('a')[1] !== undefined) {
-        const detailedFilepath = oneBill.children[4]
-          .querySelectorAll('a')[1]
+      if (oneBill.querySelectorAll('[id*="lien-"]').length > 1) {
+        const detailedFilepath = oneBill
+          .querySelector('[id*="lien-telecharger-fadet"]')
           .getAttribute('href')
+        this.log(
+          'info',
+          `detailedFilePath : ${JSON.stringify(detailedFilepath)}`
+        )
         const detailed = detailedFilepath.match('detail') ? true : false
         const detailedBill = {
           ...computedBill
         }
         detailedBill.filename = await getFileName(
-          date,
+          `${year}/${month}/${day}`,
           amount,
           currency,
           detailed
         )
-        const fileurl = `${BASE_CLIENT_URL}${detailedFilepath}`
-        const response = await ky.get(fileurl).blob()
-        const dataUri = await blobToBase64(response)
-        detailedBill.dataUri = dataUri
+        detailedBill.fileurl = `${BASE_CLIENT_URL}${detailedFilepath}`
         oldBills.push(detailedBill)
       }
-      const response = await ky.get(fileurl).blob()
-      const dataUri = await blobToBase64(response)
-      computedBill.dataUri = dataUri
       oldBills.push(computedBill)
+      counter++
+    }
+    this.log('debug', 'Old bills fetched')
+    return oldBills
+  }
+
+  async findAltOldBills(contractName) {
+    this.log('info', '📍️ findAltOldBill starts')
+    let oldBills = []
+    const allBillsElements = document
+      .querySelector('#historique')
+      .querySelectorAll('.sr-container-content-line')
+    let counter = 0
+    for (const oneBill of allBillsElements) {
+      this.log(
+        'info',
+        `fetching bill ${counter + 1}/${allBillsElements.length}...`
+      )
+      const rawAmount = oneBill.children[0].querySelector('span').innerHTML
+      const fullAmount = rawAmount
+        .replace(/&nbsp;/g, '')
+        .replace(/ /g, '')
+        .replace(/\n/g, '')
+      const amount = parseFloat(fullAmount.replace('€', '').replace(',', '.'))
+      const currency = fullAmount.replace(/[0-9]*/g, '').replace(',', '')
+      const datesElements = Array.from(oneBill.children).filter(
+        element => element.tagName === 'SPAN'
+      )
+      const filepath = oneBill.querySelector('a').getAttribute('href')
+      const fileurl = `${BASE_CLIENT_URL}${filepath}`
+      let computedBill = {
+        amount,
+        currency: currency === '€' ? 'EUR' : currency,
+        vendor: 'sfr',
+        fileurl,
+        subPath: contractName,
+        fileAttributes: {
+          metadata: {
+            contentAuthor: 'sfr',
+            datetimeLabel: 'issueDate',
+            isSubscription: true,
+            issueDate: new Date(),
+            carbonCopy: true
+          }
+        }
+      }
+
+      if (datesElements.length >= 2) {
+        this.log('info', 'Found a payment date')
+        const rawPaymentDate =
+          datesElements[0].innerHTML.match(/\d{2}\/\d{2}\/\d{4}/g)[0]
+        const foundDate = rawPaymentDate.replace(/\//g, '-').trim()
+        const [paymentDay, paymentMonth, paymentYear] = foundDate.split('-')
+        const paymentDate = new Date(
+          `${paymentMonth}/${paymentDay}/${paymentYear}`
+        )
+        const innerhtmlIssueDate = datesElements[1].innerHTML
+        const foundIssueDate = innerhtmlIssueDate.split('-')[1].trim()
+        const [issueDay, issueMonth, issueYear] = foundIssueDate.split(/\//g)
+        const issueDate = new Date(`${issueMonth}/${issueDay}/${issueYear}`)
+        computedBill.paymentDate = paymentDate
+        computedBill.date = issueDate
+        computedBill.fileAttributes.metadata.datetime = issueDate
+        computedBill.filename = await getFileName(
+          `${issueYear}-${issueMonth}-${issueDay}`,
+          amount,
+          currency
+        )
+      } else {
+        this.log('info', 'Only one element present')
+        const elementInnerhtml = datesElements[0].innerHTML
+        if (elementInnerhtml.includes('Payé le')) {
+          const [innerhtmlPaymentDate, innerhtmlIssueDate] =
+            elementInnerhtml.split('- </span>')
+
+          const foundPaymentDate = innerhtmlPaymentDate
+            .split('le')[1]
+            .replace('</span>', '')
+            .trim()
+          const [paymentDay, paymentMonth, paymentYear] =
+            foundPaymentDate.split('/')
+          const paymentDate = new Date(
+            `${paymentMonth}/${paymentDay}/${paymentYear}`
+          )
+
+          const foundIssueDate = innerhtmlIssueDate
+            .split('mensuelle -')[1]
+            .replace('</span>', '')
+            .trim()
+          const [issueDay, issueMonth, issueYear] = foundIssueDate.split(/\//g)
+          const issueDate = new Date(`${issueMonth}/${issueDay}/${issueYear}`)
+          computedBill.paymentDate = paymentDate
+          computedBill.date = issueDate
+          computedBill.fileAttributes.metadata.datetime = issueDate
+          computedBill.filename = await getFileName(
+            `${issueYear}-${issueMonth}-${issueDay}`,
+            amount,
+            currency
+          )
+        } else {
+          this.log('info', 'Element does not includes "payé le"')
+          const foundIssueDate = elementInnerhtml.split('-')[1].trim()
+          const [issueDay, issueMonth, issueYear] = foundIssueDate.split(/\//g)
+          const issueDate = new Date(`${issueMonth}/${issueDay}/${issueYear}`)
+          computedBill.date = issueDate
+          computedBill.fileAttributes.metadata.datetime = issueDate
+          computedBill.filename = await getFileName(
+            `${issueYear}-${issueMonth}-${issueDay}`,
+            amount,
+            currency
+          )
+        }
+      }
+      oldBills.push(computedBill)
+      counter++
     }
     this.log('debug', 'Old bills fetched')
     return oldBills
   }
 
   async getReloginPage() {
+    this.log('info', '📍️ getReloginPage starts')
     if (document.querySelector('#password')) {
       return true
     }
@@ -625,7 +858,6 @@ connector
       'getReloginPage',
       'getUserIdentity',
       'getContracts',
-      'waitForCurrentContract',
       'waitForRedUrl',
       'isRedUrl'
     ]


### PR DESCRIPTION
This PR fixes bills scraping for all contract.

Now instead of downloading the dataUri for every files from the website with ky then pass this dataUri to the pilot we're just taking advantage of the "downloadFileInWorker" methods implemented later  after the development of this konnector.
We're doing for 2 reasons : 
- It causes some severe issue with memory on the device, stocking 24/42 files in the worker lead the AA to just crash, but paired with all the other background applications runing on the device.
- It's now the prefered method, thanks to "downloadFileInWorker" function.

We also avoid some useless navigation and the use of pwaitFor for selecting the contract (instead of clicking until the page load, we're clicking once and wait for the page to load, leading to less instability)

Some corrections has been made on the filename, I noticed some comas where it shouldn't be and some amount badly parsed because of a coma between the integer and the decimal part.