### PR TITLE
feat: Add banksTransactionRegExp

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -73,6 +73,7 @@
       }
     }
   },
+  "banksTransactionRegExp": "\\bSfr\\b",
   "qualification_labels": [
     "isp_invoice"
   ],


### PR DESCRIPTION
In order to make the matching between a bill and a transaction, let's add the `banksTransactionRegExp` attribute

Here is an exemple: `Sfr Sfr Mobile Prlvt Sepa 99-17tek4-01 003381596467 003381596467 99-17tek4-01 ++gp201310201061096783 Fr44zzz332801`