### PR TITLE
[SCR-617] feat: Remove 'telecom' category from manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -10,7 +10,6 @@
   "editor": "Cozy",
   "vendor_link": "https://www.sfr.fr/",
   "categories": [
-    "telecom",
     "isp"
   ],
   "folders": [


### PR DESCRIPTION
Remove telecom category from manifest for the konnector to be displayed in only one category in the store