### PR TITLE
Fix/missing bills infos

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -473,15 +473,15 @@ class SfrContentScript extends ContentScript {
   async getContracts() {
     this.log('info', '📍️ getContracts starts')
     const contracts = Array.from(
-      document
-        .querySelector(
-          `a[href='https://espace-client.sfr.fr/gestion-ligne/lignes/ajouter']`
-        )
-        .parentNode.parentNode.querySelectorAll('li')
+      document.querySelectorAll(`body > nav > ul > li`)
     )
-      .filter(el => !el.getAttribute('class'))
+      .filter(el =>
+        el.querySelector('a').getAttribute('href').startsWith('?e=')
+      )
       .map(el => {
-        const text = el.textContent.trim()
+        const lineNumber = el.querySelector('h4').textContent.trim()
+        const contractStatus = el.querySelector('p').textContent.trim()
+        const text = `${lineNumber} ${contractStatus}`
         let type
         if (text.startsWith('06') || text.startsWith('07')) {
           type = 'mobile'
@@ -489,7 +489,10 @@ class SfrContentScript extends ContentScript {
           type = 'fixe'
         }
         return {
-          id: el.getAttribute('id') || 'current',
+          // No more "id" attributes available, got to find it in the href
+          id:
+            el.querySelector('a').getAttribute('href').split('?e=')[1] ||
+            'current',
           text,
           type
         }

--- a/src/index.js
+++ b/src/index.js
@@ -296,8 +296,24 @@ class SfrContentScript extends ContentScript {
     }
     await Promise.race([
       this.waitForElementInWorker('#blocAjax'),
-      this.waitForElementInWorker('#historique')
+      this.waitForElementInWorker('#historique'),
+      this.waitForElementInWorker('h1', {
+          includesText: 'information facture indisponible'
+        })
     ])
+    this.log('info', 'Checking for bills availability')
+      if (
+        await this.isElementInWorker('h1', {
+          includesText: 'information facture indisponible'
+        })
+      ) {
+        this.log(
+          'warn',
+          'Bills information are not available, ending execution'
+        )
+        throw new Error('VENDOR_DOWN')
+      }
+    this.log('info', 'Bills available, fetching them ...')
     const altButton = await this.isElementInWorker('#plusFac')
     const normalButton = await this.isElementInWorker(
       'button[onclick="plusFacture(); return false;"]'


### PR DESCRIPTION
This PR fixes :

- Crashing when no bills are found at all, it now crashes properly with the right error
- Fix the contract info scraping. Website changes lead to uncomplete contract infos, creating some directories with weird name on the cozy
- Fix the in-between contracts navigation. Navigation wasn't working properly after websites changes, leading the konnector to loop on the same bills (on the first contract) for all found contracts